### PR TITLE
fix: redirect to conference.asyncapi.com instead

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -1,1 +1,1 @@
-https://www.asyncapiconf.com/* https://conference.2020.asyncapi.com/:splat 301!
+https://www.asyncapiconf.com/* https://conference.asyncapi.com/:splat 301!


### PR DESCRIPTION
Make redirect point to conference.asyncapi.com instead.
