### PR TITLE
feat: remove registration and add links to streams

### DIFF
--- a/sources/pug/pages/index.pug
+++ b/sources/pug/pages/index.pug
@@ -29,18 +29,22 @@ block page
                 .unit-body
                   h5 $5000
                   p Winner
+                  a(href="https://github.com/asyncapi/community/discussions/128") Souvik De
             li
               .unit
                 .unit-left: +svg-icon(`euro`)(class='svg-icon-sm svg-icon-primary' )
                 .unit-body
                   h5 $3000
                   p Runner-up
+                  a(href="https://github.com/asyncapi/community/discussions/149") Ace
             li
               .unit
                 .unit-left: +svg-icon(`euro`)(class='svg-icon-sm svg-icon-primary' )
                 .unit-body
-                  h5 $1000
-                  p 3rd
+                  h5 $3000
+                  p Runner-up
+                  a(href="https://github.com/asyncapi/community/discussions/147") Greg Meldrum
+
           p We bring to you a month-long hackathon. Its goal is to provide MVP solutions that can help AsyncAPI Community in ways like:
             ul
               li Ease education and getting started with the project
@@ -343,16 +347,16 @@ block page
       h6 Great communities helping us
       h3 Event Partners
 
-      .row
-        .col-md-6.offset-md-3
-          h4(style='font-weight:normal;') We accept any kind of help
-          h4(style='font-weight:normal;' class='text-underline') <a target="_blank" href="mailto:info@asyncapi.io">Become a partner!</a>
+      //- .row
+      //-   .col-md-6.offset-md-3
+      //-     h4(style='font-weight:normal;') We accept any kind of help
+      //-     h4(style='font-weight:normal;' class='text-underline') <a target="_blank" href="mailto:info@asyncapi.io">Become a partner!</a>
 
       .row
         .col-md-10.offset-md-1
           .row
             center
-              .col-md-2  
+              .col-md-4   
                 a(href='https://restream.io' target='_blank')
                   img(src='/images/partners/restream.png') 
 

--- a/sources/pug/sections/_section-swiper-slider-modern.pug
+++ b/sources/pug/sections/_section-swiper-slider-modern.pug
@@ -42,6 +42,14 @@ section.section.section-swiper-absoulte.context-dark.text-center( data-triangle=
             a.button.button-primary.box-with-triangle-right.wow.fadeScale( href='https://www.twitch.tv/asyncapi' target="_blank" data-triangle=".button-overlay" )
               span Twitch
               span.button-overlay
+        
+        .row
+          .col-md-8.offset-md-2
+            h4(style='font-weight:normal;') Comment and Ask Questions
+        
+            a.button.button-secondary.box-with-triangle-right.wow.fadeScale( href='https://www.asyncapi.com/slack-invite' target="_blank" data-triangle=".button-overlay" )
+              span Slack #conference2021
+              span.button-overlay
         //- .row
         //-   .col-md-6.offset-md-3
         //-     h4(style='font-weight:normal;') CFP is still open!

--- a/sources/pug/sections/_section-swiper-slider-modern.pug
+++ b/sources/pug/sections/_section-swiper-slider-modern.pug
@@ -27,10 +27,20 @@ section.section.section-swiper-absoulte.context-dark.text-center( data-triangle=
               .unit-left.line-height-reset: +svg-icon('small-calendar')(class='svg-icon-sm svg-icon-primary')
               .unit-body: h5.text-spacing-100: span.big: time(datetime='2021-11-16') Conference November 16-18, 2021
         .row
-          .col-md-6.offset-md-3
-            h4(style='font-weight:normal;') Conference Registration
-            a.button.button-primary.box-with-triangle-right.wow.fadeScale( href='https://zoom.us/webinar/register/9416323899487/WN_pv8NDGIoSg2CnF9qsoptWw' target="_blank" data-triangle=".button-overlay" )
-              span Register for free
+          .col-md-8.offset-md-2
+            h4(style='font-weight:normal;') Join Live Stream
+        
+            a.button.button-facebook.box-with-triangle-right.wow.fadeScale( href='https://linkedin.com/company/asyncapi' target="_blank" data-triangle=".button-overlay" )
+              span LinkedIn
+              span.button-overlay
+            a.button.button-google.box-with-triangle-right.wow.fadeScale( href='https://www.youtube.com/asyncapi' target="_blank" data-triangle=".button-overlay" )
+              span YouTube
+              span.button-overlay
+            a.button.button-twitter.box-with-triangle-right.wow.fadeScale( href='https://twitter.com/AsyncAPISpec' target="_blank" data-triangle=".button-overlay" )
+              span Twitter
+              span.button-overlay
+            a.button.button-primary.box-with-triangle-right.wow.fadeScale( href='https://www.twitch.tv/asyncapi' target="_blank" data-triangle=".button-overlay" )
+              span Twitch
               span.button-overlay
         //- .row
         //-   .col-md-6.offset-md-3


### PR DESCRIPTION
We should display in one place link to all the accounts where live stream will be available.

Opened for suggestions how to improve it. I can even close this PR in favour of something different.

My only strong opinion is that these should be links and not embedded video for example from YouTube as taking users to the specific platform to our account could convert into a "follow"

I also added info about winners of the hackathon