### PR TITLE
fix: added width to SVG

### DIFF
--- a/components/Form/form.js
+++ b/components/Form/form.js
@@ -150,7 +150,7 @@ function Form() {
               transform: "scaleX(-1)",
             }}
           >
-            <Pattern2 className="w-full sm:w-12" />
+            <Pattern2 className="w-72 sm:w-12" />
           </div>
         </div>
       </div>

--- a/components/Header/header.js
+++ b/components/Header/header.js
@@ -16,7 +16,7 @@ function Header() {
         <img src="dots.svg" alt="dots"/>
       </div>
       <div className="absolute right-0">
-        <Pattern1 className="w-full sm:w-32" />
+        <Pattern1 className="w-72 sm:w-32" />
       </div>
       <div className="absolute flex justify-center flex-col items-center mt-20 w-full sm:px-32">
         <div>
@@ -56,7 +56,7 @@ function Header() {
         </div>
       </div>
       <div className="absolute bottom-0 opacity-50 sm:hidden">
-       <Polygon className="w-full" />
+       <Polygon className="w-72" />
       </div>
     </div>
   );


### PR DESCRIPTION
This PR targets to add the width on the SVG (Patterns) to correct the view of the website in the FIrefox browser.

**Note:** Please ignore the slight change in the width of the Patterns as the width classes of the Tailwind are added to the Patterns.