### PR TITLE
fix: link date button to Google Calendar 

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -62,7 +62,7 @@ export default function Home() {
         <div className='p-9 bg-tetiary-pink w-[480px] lg:w-[50%] sm:w-[80%] h-[300px] sm:h-[auto] sm:ml-[0px] lg:ml-[100px] text-right lg:text-center z-[2]'>
           <p className='text-md'>LONDON EDITION In <br /> IBM UK LIMITED</p>
             <div>
-              <button className='mt-12 bg-white border border-black p-2 text-lg rounded-3xl'>September 20, 2023</button>
+              <a target="_blank" href="https://calendar.google.com/calendar/u/0/embed?src=c_q9tseiglomdsj6njuhvbpts11c@group.calendar.google.com&ctz=UTC"><button className='mt-12 bg-white border border-black p-2 text-lg rounded-3xl'>September 20, 2023</button></a>
           </div>
         </div>
         <div className='p-9 bg-tetiary-pink -mt-[250px] h-[250px] lg:ml-[350px] z-[1] lg:mt-[0px] w-[390px] sm:hidden lg:w-[50%] mr-[5px]'>


### PR DESCRIPTION
**Description**
Fixes the link to Date button on 2023 Conference Website to Google Calendar Event.

**Related issue(s)**
Fixes #146 