### PR TITLE
feat: remove Fawaz from madrid speaker

### DIFF
--- a/config/speakers.json
+++ b/config/speakers.json
@@ -32,11 +32,6 @@
 				"name": "Alejandra Quetzalli",
 				"title": "Author & Lead Documentation Engineer",
 				"img": "https://cache.sessionize.com/image/6025-200o200o2-DqDUFbrp2qMozbpyx1T5rZ.JPG"
-			},
-			{
-				"name": "Fawaz Ghali",
-				"title": "Hazelcast, Principal Data Science Architect and Head of Developer Relations",
-				"img": "https://sessionize.com/image/3405-200o200o2-N7uKxHJji5AywKmqaTbC3G.jpg"
 			}
 		]
 	},


### PR DESCRIPTION
Fawaz will no longer be participating as a speaker in Madrid, This PR will update the speakers section.