### PR TITLE
fix: remove duplicate speakers

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -35,6 +35,11 @@ export default function Home() {
 			speakers[0].lists.push(...speaker.lists);
 		}
 	});
+	const list = speakers[0].lists.filter((obj, index) => {
+		return index === speakers[0].lists.findIndex(o => obj.name=== o.name);
+	});
+	speakers[0].lists =[...list];
+	
 	useEffect(() => {
 		setCity(speakers[0]);
 		setSpeakersList(speakers[0].lists);


### PR DESCRIPTION

![screencapture-localhost-3000-2023-11-09-09_25_04](https://github.com/asyncapi/conference-website/assets/98829227/478441d7-80d0-4076-8b72-6b094734fa6f)

- Remove duplicate speakers from all speaker sections



Resolves  #239
