### PR TITLE
fix: margins and paddings of hero section

### DIFF
--- a/components/Navbar/navDrop.js
+++ b/components/Navbar/navDrop.js
@@ -8,8 +8,8 @@ const NavDrop = forwardRef((props, ref)=> {
 	const {setDrop}=props;
     const [show, setShow] = useState(null);
   return (
-		<div  ref ={ref} className='absolute ml-[-16px] top-16 w-full bg-[#1B1130]'>
-			<div className='flex flex-col p-4 pb-8 w-full'>
+		<div  ref ={ref} className='absolute ml-[-20px] top-16 w-full bg-[#1B1130]'>
+			<div className='flex flex-col p-5 pb-8 w-full'>
 				{links.map((link) => {
 					return (
 						<Link href={link.ref} key={link.title}>

--- a/components/Navbar/navbar.js
+++ b/components/Navbar/navbar.js
@@ -41,7 +41,7 @@ function Navbar() {
 	return (
 		<div className='flex justify-center items-center sticky top-0 z-[99] text-white'>
 			<div className='w-[1131px]'>
-				<div className='flex justify-between h-[75px] w-full items-center'>
+				<div className='p-5 flex justify-between h-[75px] w-full items-center'>
 					<div className='flex items-center sm:justify-between sm:w-full'>
 						<Link href='/'>
 							<div className='flex items-center cursor-pointer w-[120px]'>


### PR DESCRIPTION
**Description**
This pull request updates the margin and padding to fix the alignment of the hero section on the website.

**Related issue(s)** Fixes #267

|Earlier|Now|
|---|---|
|![image](https://github.com/asyncapi/conference-website/assets/96991785/0ccdaf02-d702-4e39-90bf-86eb33f076d5)|![Screenshot](https://github.com/asyncapi/conference-website/assets/96991785/7017ba9e-e5ae-49d7-b977-e0813ebe17b6)|
|![image](https://github.com/asyncapi/conference-website/assets/96991785/72009ec0-3ec5-40cc-933a-b2a442c3d7ea)|![Screenshot](https://github.com/asyncapi/conference-website/assets/96991785/6150bb41-5922-4ad2-88db-7505ae7b4418)|




