### PR TITLE
fix: description of Tickets Sale and Event and Host Sponsor is not visible

### DIFF
--- a/components/Sponsors/sponsors.js
+++ b/components/Sponsors/sponsors.js
@@ -8,7 +8,7 @@ function Sponsors({imgs}) {
 		<div className='sponsor-bg container text-center'>
 			<div className='py-[80px] flex flex-col items-center'>
 				<Heading typeStyle='heading-md' className='text-white'>Event and Host Sponsor</Heading>
-				<div className='w-[718px] sm:w-full'>
+				<div className='max-w-3xl sm:w-full'>
 					<Paragraph className='mt-[40px]' textColor='text-white'>
 						Elevating the future of APIs. Our valued partners and sponsors play
 						a pivotal role in bringing our vision to life. With their support, we 

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,7 +33,7 @@ export default function Home() {
 			<Heading typeStyle='heading-md' className='text-gradient text-center lg:mt-10'>
 				Tickets Sale [Coming Soon]
 			</Heading>
-			<div className='w-[718px] sm:w-full text-center'>
+			<div className='max-w-3xl sm:w-full text-center'>
 			<Paragraph typeStyle='body-lg' className="mt-6" textColor='text-gray-200' >
 			Experience the Future of Asynchronous Communication: Tickets for Sale for the AsyncAPI Conference on Tour!
 			</Paragraph>


### PR DESCRIPTION
Issue #302 
close #302 


**Description**
[Fix:](fix:Description of Tickets Sale and Event and Host Sponsor is not visible)
![Screenshot 2024-04-05 114447](https://github.com/asyncapi/conference-website/assets/125847751/515534ae-189e-4fac-8c5f-2f92f6f23adc)
![Screenshot 2024-04-05 114457](https://github.com/asyncapi/conference-website/assets/125847751/ef838499-dc99-4e68-89d8-ccffffa42c62)
