### PR TITLE
fixed the padding design of the about

### DIFF
--- a/components/About/about.js
+++ b/components/About/about.js
@@ -6,7 +6,7 @@ import Button from '../Buttons/button';
 
 function About() {
     return (
-		<div className='p-24 container flex items-center justify-center w-full'>
+		<div className='px-24 py-6 container flex items-center justify-center w-full'>
 			<div className='w-[1120px] lg:w-full flex lg:flex-col-reverse items-center justify-between'>
 				<div style={{'--image-url': `url('/img/about.jpeg')`}} className='lg:mt-16 bg-[image:var(--image-url)] bg-center bg-cover w-[450px] h-[550px] sm:w-[100%] sm:h-[500px] rounded-[30px]' >
 			</div>


### PR DESCRIPTION
Fixes: #318 

to see the issue click on the about on navbar

before: 
<img width="1244" alt="image" src="https://github.com/asyncapi/conference-website/assets/122612557/b9c60998-5f68-4242-807d-860dc31c2086">

after:
<img width="1256" alt="image" src="https://github.com/asyncapi/conference-website/assets/122612557/27dc864f-aba2-4135-9efe-8768bfe4393a">

