### PR TITLE
fix: change img tags to Image of next/image

### DIFF
--- a/components/Sponsors/sponsors.js
+++ b/components/Sponsors/sponsors.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Heading from '../Typography/heading';
 import Paragraph from '../Typography/paragraph';
+import Image from 'next/image';
 
 function Sponsors({imgs}) {
   return (
@@ -20,14 +21,13 @@ function Sponsors({imgs}) {
 					{imgs &&
 						imgs.map((img) => (
 							<div key={img} className='w-[300px] h-[150px] flex items-center'>
-								<img src={img} alt={img} className='' />
+								<Image src={img} alt={img} height={210} width={300}/>
 							</div>
 						))}
 				</div>
 				<div className=' flex space-y-2 flex-col items-center justify-center text-white text-2xl font-bold'>
 				<Heading typeStyle='heading-md' className='text-white mb-12 sm:text-2xl'>Financial Sponsor</Heading>
-					
-					<img src="/img/graviteeio.svg"  alt='financial sponsor' width={250} />
+					<Image src="/img/graviteeio.svg" alt='financial sponsor' width={250} height={50} />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Replaced `<img>` tag from [sponsor.js](https://github.com/asyncapi/conference-website/blob/master/components/Sponsors/sponsors.js) file to `<Image>`  tag.
- Could not replace from [index.js](https://github.com/asyncapi/conference-website/blob/ae1f6331f8c563089c354d6d78298d64ceaebac6/pages/index.js#L46) file as it uses dynamic width from external css and `<Image>` requires `width={}` and `height={}` as input so can't override with external css as inline css >> external css.

**Related issue(s)**
Fixes #340 