### PR TITLE
fix: #342 (fixed the extra magin on top for small devices)

### DIFF
--- a/components/Form/subscription.js
+++ b/components/Form/subscription.js
@@ -1,25 +1,24 @@
 import React from 'react';
 import Button from '../Buttons/button';
 
-function Subcription() {
+function Subscription() {
 	return (
-		<div className='mt-[106px] subscription container flex justify-center'>
-			<div className='w-[1024px] min-h-[253px] lg:py-10 lg:w-full flex flex-col items-center mt-[106px]'>
+		<div className='mt-0 md:mt-[106px] subscription container flex justify-center'>
+			<div className='mt-[106px] lg:mt-0 w-[1024px] min-h-[253px] lg:py-10 lg:w-full flex flex-col items-center'>
 				<h3 className='text-[32px] text-white lg:text-center'>
 					Subscribe for AACoT’24 updates!
 				</h3>
 				<a href='https://www.asyncapi.com/newsletter' target='_blank' rel="noreferrer" className='sm:w-full'>
-				<Button
-					type='submit'
-					className='w-full md:w-[200px] mt-8 px-10' 
-				>
-					Subscribe
-				</Button>
-
+					<Button
+						type='submit'
+						className='w-full md:w-[200px] mt-8 px-10'
+					>
+						Subscribe
+					</Button>
 				</a>
 			</div>
 		</div>
 	);
 }
 
-export default Subcription;
+export default Subscription;

--- a/pages/index.js
+++ b/pages/index.js
@@ -176,7 +176,7 @@ export default function Home() {
 			<div id='sponsors' className='mt-20'>
 				<Sponsors imgs={['/img/apidays.png']} />
 			</div>
-			<div className='-mt-5'>
+			<div className='mt-5'>
 			<Subcription/>
 			</div>
 		</div>


### PR DESCRIPTION
**Description**

changed mt-[106px] lg:mt-0  in the second div where margin for small devices is mt-0 and for large devices mt-[106px]

Before :-
![before](https://github.com/asyncapi/conference-website/assets/115611556/74a33c64-114e-4a65-9bf7-0279e2e96ba6)


After:- 
![after](https://github.com/asyncapi/conference-website/assets/115611556/be780b19-3996-442f-8aa9-645b3714a19f)

- ...
- ...
- ...

**Related issue(s)**
#342 