### PR TITLE
fix: fixed smtp pass typo

### DIFF
--- a/pages/api/speakers/register/index.js
+++ b/pages/api/speakers/register/index.js
@@ -38,7 +38,7 @@ export default async function handler(req, res) {
         secure: true, 
         auth: {
             user: process.env.ASYNCAPI_EMAIL,
-            pass: process.env.GOOOGLE_APP_PASSWORD,
+            pass: process.env.GOOGLE_APP_PASSWORD,
         },
         });
 


### PR DESCRIPTION
fixed typo not allowing email confirmation when submitting talk for the online conference. 