### PR TITLE
fix: logical render error in agenda component

### DIFF
--- a/components/Agenda/agenda.js
+++ b/components/Agenda/agenda.js
@@ -28,7 +28,7 @@ function Agenda({ city }) {
 			  
 			  <div className='mt-[40px]'>
 				  {city.agenda.map((talk) => {
-					  return <div key={talk.session} className={`flex sm:flex-col justify-between mt-[50px] ${!talk.speaker && 'countdown-text-gradient'}`}>
+					  return <div key={talk.time} className={`flex sm:flex-col justify-between mt-[50px] ${!talk.speaker && 'countdown-text-gradient'}`}>
 						  <Paragraph typeStyle='body-md'>
 							  {talk.time}
 						  </Paragraph>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

![photo_6165458212795565896_x](https://github.com/user-attachments/assets/d0047979-680e-40ae-8f74-ba159b84e422)

- Logical render issue was due to ```talk.session``` being used as a key to render ```div```. This resulted in the react not being able to identify which div in agenda to rerender and ultimately rendering the break divs again. 
- Changing the key to ```talk.time``` which is unique to each break as well solved the issue.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #456 