### PR TITLE
feat: add conference recordings to Online venue

### DIFF
--- a/config/city-lists.json
+++ b/config/city-lists.json
@@ -13,7 +13,9 @@
 		],
 		"ticket": false,
 		"isFree": true,
-		"ended": true
+		"ended": true,
+		"recordings": "https://www.youtube.com/playlist?list=PLbi1gRlP7pijItMBmw9SeeyWxuEa3jLR2",
+        "playlist": "https://www.youtube.com/embed/videoseries?list=PLbi1gRlP7pijItMBmw9SeeyWxuEa3jLR2"
 
 	},
 	{


### PR DESCRIPTION
Added conference recording playlist configuration to the Online venue to make sessions easily accessible to attendees directly from the venue page
Added recordings and playlist URLs to Online venue configuration in city-lists.json

Before:
![scrnli_IvKh07LAp3CXSx](https://github.com/user-attachments/assets/615e45d8-084b-4ca0-994d-8300bf9981e2)

After:
![scrnli_0AYXn26ty4t394](https://github.com/user-attachments/assets/1fa9942e-7504-471b-930f-2ed2078a8808)
![scrnli_6K43Z0sGS4sZ1J](https://github.com/user-attachments/assets/3f571390-992b-4605-b440-5d3b9f721059)

fixes [issue](https://github.com/asyncapi/conference-website/issues/452#issue-2630012422)



