### PR TITLE
feat: Added borders and background colors to speaker images for consistent card designs

### DIFF
--- a/components/Speaker/speaker.js
+++ b/components/Speaker/speaker.js
@@ -7,7 +7,7 @@ function Speaker({details, location, className}) {
 			className={`w-auto text-center flex flex-col items-center card h-auto rounded-md p-[27px] ${className}`}
 			data-test="speakers-section"
 		>
-			<div className='w-[300px] h-[300px] lg:w-[250px] lg:h-[250px] relative overflow-hidden  rounded-full border-2 border-gray-400 bg-gray-800'>
+			<div className='w-[300px] h-[300px] lg:w-[250px] lg:h-[250px] relative overflow-hidden  rounded-full  border-2  border-gray-400 bg-gray-800'>
 				<Image src={details.img} alt={details.name} width={0} height={0} sizes='100vw' className='rounded-full object-cover transition-all duration-300 hover:scale-110 w-[100%] h-[100%]' />
 			</div>
 			<div className='mt-[19px]'>

--- a/components/Speaker/speaker.js
+++ b/components/Speaker/speaker.js
@@ -7,7 +7,7 @@ function Speaker({details, location, className}) {
 			className={`w-auto text-center flex flex-col items-center card h-auto rounded-md p-[27px] ${className}`}
 			data-test="speakers-section"
 		>
-			<div className='w-[300px] h-[300px] lg:w-[250px] lg:h-[250px] relative overflow-hidden  rounded-full'>
+			<div className='w-[300px] h-[300px] lg:w-[250px] lg:h-[250px] relative overflow-hidden  rounded-full border-2 border-gray-400 bg-gray-800'>
 				<Image src={details.img} alt={details.name} width={0} height={0} sizes='100vw' className='rounded-full object-cover transition-all duration-300 hover:scale-110 w-[100%] h-[100%]' />
 			</div>
 			<div className='mt-[19px]'>


### PR DESCRIPTION
Description:
as attached, some speaker images are in the from of transparent background which makes the design of the card inconsistent across the website.

Changes include:
- Added a border to speaker images to ensure consistency across the website.
- Fixed layout issues for speaker images with transparent backgrounds.
- Updated the `Speaker` component styles by adding a border and background color to image containers.

Related issue(s):
![Screenshot (314)](https://github.com/user-attachments/assets/4cac8a71-e1a8-440a-9379-622427b7f0db)
![Screenshot (315)](https://github.com/user-attachments/assets/d49f18b6-ec4a-4e27-97b5-d843a9bc31a2)

Fixes #485
