### PR TITLE
fix: dynamically adjust dropdown width to prevent text wrapping

### DIFF
--- a/components/Navbar/navbar.js
+++ b/components/Navbar/navbar.js
@@ -122,7 +122,7 @@ function Navbar() {
                                        <span className="after:absolute after:-bottom-1 after:right-1/2 after:w-0 after:transition-all after:h-0.5 after:bg-white after:group-hover:w-3/6"></span>
 										{show === link.title && link.subMenu && (
 											<div
-												className='subMenu absolute z-[9] mt-8 w-[150px] rounded-md left-[-15px] gradient-bg px-2 py-1 flex flex-col justify-center space-y-0'
+												className='subMenu absolute z-[9] mt-8 min-w-max max-w-full rounded-md left-[-15px] gradient-bg px-2 py-1 flex flex-col justify-center space-y-0'
 												onMouseEnter={handleSubMenuEnter}
 												onMouseLeave={handleSubMenuLeave}>
 												{link.subMenu.map((subL) => (


### PR DESCRIPTION
### Description
This PR addresses the issue where the dropdown menu in the navigation bar had a fixed width, causing text wrapping for longer items and excessive space for shorter items. The dropdown width now adjusts dynamically based on the length of the longest link, ensuring a more consistent and responsive UI.

**Screenshot**
![DropDownIssueSolved](https://github.com/user-attachments/assets/ccf7b352-3ada-4b5f-8916-792922a4adb2)

Fixes #503 