### PR TITLE
fix: cutoff header word in mobile view at venue page

### DIFF
--- a/pages/venue/[id].js
+++ b/pages/venue/[id].js
@@ -43,7 +43,7 @@ function Venue({ city }) {
 		<div data-test={`venue-${city.name}`}>
 			<div className= {`w-full h-[500px] sm:h-[auto] ${city.name=='Online'?'bg-online':'bg-madrid'} bg-cover bg-center`}>
 				<div className='w-full h-full kinda-dark items-center flex flex-col justify-between'>
-					<div className='mt-[60px] container text-center flex flex-col items-center w-[1100px] lg:w-full sm:text-center'>
+					<div className='mt-[68px] container text-center flex flex-col items-center w-[1100px] lg:w-full sm:text-center'>
 						{city.name == 'Online' ? <Heading className={textColor}>
 							{city.name} {city.country}
 						</Heading> :


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

the location header in the venue is getting cut off by the nav during the mobile view
before:
<img width="473" alt="image" src="https://github.com/user-attachments/assets/760fc6ee-b9d5-4c22-819d-b44351cdd375" />


after:
<img width="481" alt="image" src="https://github.com/user-attachments/assets/005b02b6-fa0b-4e85-b8a7-422a05aa561a" />

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes: #517