### PR TITLE
fix: spacing fix for location button

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -95,7 +95,7 @@ export default function Home() {
                   </div>
                 ) : (
                   <div className="flex justify-center">
-                    <div className="w-[900px] lg:w-full flex justify-between">
+                    <div className="space-x-4 lg:w-full flex justify-between">
                       {speakers.map((speaker) => {
                         return (
                           <div


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

fix the spacing for the location button
before
<img width="1512" alt="Screenshot 2025-03-05 at 12 29 15 PM" src="https://github.com/user-attachments/assets/659dac30-c73a-4e63-b3ba-5ebc01054637" />

after
<img width="1512" alt="Screenshot 2025-03-05 at 12 28 05 PM" src="https://github.com/user-attachments/assets/1bcb26d5-3a36-4167-8185-964a6aa3b23b" />





**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->