### PR TITLE
fix: make Code of Conduct button visible on small screens

### DIFF
--- a/components/Footer/footer.tsx
+++ b/components/Footer/footer.tsx
@@ -31,7 +31,7 @@ function Footer(): JSX.Element {
             Made with ❤️ by AsyncAPI contributors. By the community for the
             community!
           </div>
-          <div className="w-[0.9px] h-4 bg-white ml-4 sm:hidden" />
+          <div className="w-[0.9px] h-4 bg-white ml-4" />
           <div className="ml-4 flex justify-between items-center gap-2 sm:mt-4">
             {socials.map((social: Social, index) => {
               return (


### PR DESCRIPTION
This PR fixes a bug where the Code of Conduct button in the footer was not visible on small screens (below 790px width). The issue was caused by the sm:hidden class, which prevented the button from rendering on smaller devices.Additionally,Updated the global styles (global.css) by cleaning unnecessary styles that are commented.

Related Issue:
fixes #594

Testing=
1. Open the website in mobile view .
2. Check if the Code of Conduct button appears correctly.

https://github.com/user-attachments/assets/e8180d02-ff4f-46f2-89ff-64a7880d35cc

@ashmit-coder @AceTheCreator Please review this pr

