### PR TITLE
fix: fix sponsor images visibility in footer section

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -233,8 +233,17 @@ export default function Home() {
         </div>
       </div>
       <div id="sponsors" className="mt-20">
-      <Sponsors eventSponsors={[{image:'/img/apidays_2.webp',websiteUrl:"https://www.apidays.global/"}]} financialSponsor={[{image:"/img/graviteeIo_1.png" , websiteUrl: "https://www.gravitee.io/",className:"w-[250px] h-[50px]" } , {image:"/img/postman_1.png" ,websiteUrl:"https://www.postman.com/",className:"w-[240px] h-[70px]"}]}  />
-      </div>
+<Sponsors
+          eventSponsors={[
+            {
+              image: "/img/logos/apidays.png",
+              websiteUrl: "https://www.apidays.global/",
+            },
+            {
+              image: "/img/logos/APICONF-LOGO-White.png",
+              websiteUrl: "https://apiconf.net/",
+            },
+          ]}/>      </div>
       <div className="mt-5">
         <Subscription />
       </div>


### PR DESCRIPTION
Fixes #607

Add sponsor images to the footer section.

* Modify `pages/index.js` to include sponsor images in the footer section.
* Add event sponsors with their respective images and website URLs.
* Ensure sponsor images are displayed alongside the social media icons in the footer section.

