### PR TITLE
fix: #503 Added Style to Acommodate the title size in the NavBar Dropdown

### DIFF
--- a/components/Navbar/navbar.js
+++ b/components/Navbar/navbar.js
@@ -114,6 +114,7 @@ function Navbar() {
                     onMouseLeave={handleMouseLeave}
                     className="ml-16 text-[14px] group cursor-pointer relative flex flex-col"
                     data-test={`nav-${link.title}`}
+                    style={{ display: "inline-block", minWidth: "max-content", whiteSpace: "nowrap" }}
                   >
                     <div>
                       {link.subMenu ? (


### PR DESCRIPTION
This fix solves the issue of dropdown menu in Navbar section. It accommodates longer title texts

Before:
![image](https://github.com/user-attachments/assets/5b89d92e-49da-4cca-ba7d-3323f126527d)

After:
![image](https://github.com/user-attachments/assets/cd5178a7-516d-4859-b5d2-cdf2427fabd4)


Fix issue: #503