### PR TITLE
Fix: #503 Styled the NavBar dropdown to accommodate title size.

### DIFF
--- a/components/Navbar/navDrop.js
+++ b/components/Navbar/navDrop.js
@@ -26,6 +26,7 @@ const NavDrop = forwardRef((props, ref)=> {
 											<div className='text-white'>{link.title}</div>
 											<Dropdown
 												className={`transition-transform duration-700`}
+												style={{ display: "inline-block", minWidth: "max-content", whiteSpace: "nowrap" }}
 											/>
 										</div>
 										{show && show === link.title && (

--- a/components/Navbar/navbar.js
+++ b/components/Navbar/navbar.js
@@ -136,7 +136,7 @@ function Navbar() {
                     <span className="after:absolute after:-bottom-1 after:right-1/2 after:w-0 after:transition-all after:h-0.5 after:bg-white after:group-hover:w-3/6"></span>
                     {show === link.title && link.subMenu && (
                       <div
-                        className="subMenu absolute z-[9] mt-8 w-[150px] rounded-md left-[-15px] gradient-bg px-2 py-1 flex flex-col justify-center space-y-0"
+                        className="subMenu absolute z-[9] mt-8 min-w-max rounded-md left-[-15px] gradient-bg px-2 py-1 flex flex-col justify-center space-y-0"
                         onMouseEnter={handleSubMenuEnter}
                         onMouseLeave={handleSubMenuLeave}
                       >


### PR DESCRIPTION
**Description**
- This Resizes the titles dropdown menu in the Navbar section.
-  Accommodates the title so that it does not have to wrap.
- Displays the entire title in a single line.

Before:
![image](https://github.com/user-attachments/assets/ac3c4651-b916-46a5-9ab6-94b501051df0)

After:
![image](https://github.com/user-attachments/assets/9c35cc1c-976a-422d-a920-0453b58939e1)


**Related issue(s)**
#503 