### PR TITLE
feat: add scroll-to-top button on page bottom scroll

### DIFF
--- a/components/Scroll-button/ScrollToTop.tsx
+++ b/components/Scroll-button/ScrollToTop.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+
+const ScrollToTop: React.FC = () => {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  const toggleVisibility = (): void => {
+    if (window.scrollY > 300) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  const scrollToTop = (): void => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', toggleVisibility);
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, []);
+
+  return (
+    isVisible && (
+      <button
+        onClick={scrollToTop}
+        className="fixed bottom-8 right-4 sm:right-8 flex items-center gap-2 px-3 sm:px-4 py-2 bg-gradient-to-r from-indigo-500 to-purple-600 text-white rounded-full shadow-lg hover:from-indigo-600 hover:to-purple-700 focus:outline-none focus:ring-4 focus:ring-offset-2 focus:ring-white focus:ring-opacity-80 active:ring-4 active:ring-white active:ring-opacity-100 z-50 transition-all duration-300 ease-in-out transform hover:scale-110"
+        style={{
+          fontSize: '0.875rem',
+          lineHeight: '1.25rem',
+          boxShadow: '0 4px 8px rgba(255, 255, 255, 0.3)',
+        }}
+        aria-label="Scroll to top"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M5 15l7-7 7 7"
+          />
+        </svg>
+        <span className="text-sm font-medium">Back to top</span>
+      </button>
+    )
+  );
+};
+
+export default ScrollToTop;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,22 +1,26 @@
 import '../styles/globals.css';
 import Navbar from '../components/Navbar/navbar';
 import Footer from '../components/Footer/footer';
+import ScrollToTopButton from '../components/Scroll-button/ScrollToTop';
+import { useState, useEffect } from 'react';
 import { AppProps } from 'next/app';
-import { useEffect, useState } from 'react';
 
-function MyApp({ Component, pageProps }: AppProps) {
-  const [isClient, setIsClient] = useState<boolean>(false);
+function MyApp({ Component, pageProps }:AppProps) {
+  const [showChild, setShowChild] = useState(false);
+
   useEffect(() => {
-    setIsClient(true);
+    setShowChild(true);
   }, []);
-  if (!isClient) {
-    return <></>;
+
+  if (!showChild || typeof window === "undefined") {
+    return null;
   }
+
   return (
     <div>
       <Navbar />
-
       <Component {...pageProps} />
+      <ScrollToTopButton />
       <Footer />
     </div>
   );


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This pull request adds a "Scroll to Top" button that appears when a user scrolls down the page. When clicked, the button smoothly scrolls the page back to the top. This improves user experience, especially on long pages, by making it easier to go back to the top without manually scrolling.


**Proof**



https://github.com/user-attachments/assets/0a4a1e63-77bb-47f1-b5eb-5df3dacdaab9







**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fix #475 