### PR TITLE
feat: interactive "Call for Speakers Paris!" button on the homepage.

### DIFF
--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -4,9 +4,7 @@ import Link from 'next/link';
 function Announcement(): JSX.Element {
   return (
     <Link href="/venue/Paris">
-      <div className="cursor-pointer border text-white min-w-[300px] rounded-lg p-1 text-center text-lg
-                      transition duration-300 ease-in-out 
-                      hover:bg-white hover:text-black hover:scale-105 hover:shadow-lg">
+      <div className="cursor-pointer border text-white min-w-[300px] rounded-lg p-1 text-center text-lg transition duration-300 ease-in-out  hover:bg-white hover:text-black hover:scale-105 hover:shadow-lg">
         Call for Speakers Paris!
       </div>
     </Link>

--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -14,3 +14,4 @@ function Announcement(): JSX.Element {
 }
 
 export default Announcement;
+

--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -4,7 +4,9 @@ import Link from 'next/link';
 function Announcement(): JSX.Element {
   return (
     <Link href="/venue/Paris">
-      <div className="cursor-pointer border text-white min-w-[300px] rounded-lg p-1 text-center text-lg">
+      <div className="cursor-pointer border text-white min-w-[300px] rounded-lg p-1 text-center text-lg
+                      transition duration-300 ease-in-out 
+                      hover:bg-white hover:text-black hover:scale-105 hover:shadow-lg">
         Call for Speakers Paris!
       </div>
     </Link>

--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -12,5 +12,4 @@ function Announcement(): JSX.Element {
     </Link>
   );
 }
-
 export default Announcement;

--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -12,4 +12,5 @@ function Announcement(): JSX.Element {
     </Link>
   );
 }
+
 export default Announcement;

--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -14,4 +14,3 @@ function Announcement(): JSX.Element {
 }
 
 export default Announcement;
-

--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 function Announcement(): JSX.Element {
   return (
-    <Link href="/venue/London">
+    <Link href="/venue/Paris">
       <div className="cursor-pointer border text-white min-w-[300px] rounded-lg p-1 text-center text-lg">
         Call for Speakers Paris!
       </div>


### PR DESCRIPTION
Fixes #782

Currently, the "Call for Speakers Paris!" button on the homepage is static and lacks interactivity, which can make it less noticeable and engaging for users. To improve user experience and visual appeal, I propose adding a subtle yet effective hover effect using TailwindCSS utilities.

Proposed Improvements:

Add hover:bg-white and hover:text-black for inverted contrast on hover.
Apply hover:scale-105 and transition duration-300 for smooth scaling and animation.
Introduce hover:shadow-lg for a modern soft-glow effect.

Result:

Better visual hierarchy on the page.
Improved accessibility and discoverability of the "Call for Speakers" action.
Consistent with modern UI interaction standards.

Component Affected: components/Announcement.tsx

Preview:

https://github.com/user-attachments/assets/874dfc4f-e4f9-4666-89b9-c7b83272c0bb

This serves as a meaningful UI contribution toward polishing and enhancing the conference website's interactivity. It aligns with the community’s interest in improving design consistency and user engagement.