### PR TITLE
fix: Popup behaviour on the landing page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Head from 'next/head';
 import { useMediaQuery } from 'react-responsive';
 import Header from '../components/Header/header';
@@ -21,9 +21,19 @@ import Popup from '../components/Popup/popup';
 export default function Home() {
   const isTablet = useMediaQuery({ maxWidth: '1118px' });
   const [speakersList, setSpeakersList] = useState(speakers);
+  const [ showpopup, setshowpopup ] = useState<boolean>(true);
   const [currentCity, setCurrentCity] = useState<Partial<City>>({
     name: 'All',
   });
+
+  useEffect(() => {
+    const hasShown = sessionStorage.getItem("popupShown");
+    if (hasShown === "true") {
+      setshowpopup(false);
+    } else {
+      sessionStorage.setItem("popupShown", "true");
+    }
+  }, []);
 
   const handleSpeakers = (city: string) => {
     if (city && city !== 'all') {
@@ -50,7 +60,7 @@ export default function Home() {
         alt="background-illustration"
       />
       <Header />
-      <Popup />
+      {showpopup && <Popup />}
       <div id="about" className="mt-20">
         <About />
       </div>


### PR DESCRIPTION
**Description**

- Added `popupShown` state persistence in `sessionStorage` so the popup only appears once per browser tab session.
- Logic works as intended in production builds. In development, React Strict Mode’s double invocation of `useEffect` may cause the popup to close immediately after showing , this is a dev-only behavior and will not occur in production.
- Prevented popup from showing again on subsequent navigations in the same tab.
- Used `sessionStorage` instead of `localStorage` because it persists only for the current browser tab and is cleared when the tab is closed, preventing the popup from being hidden across completely new browsing sessions.

**Related issue(s)**
See also #788 