### PR TITLE
fix: keep closed tickets visible at the bottom with disabled styling

### DIFF
--- a/components/Tickets/tickets.tsx
+++ b/components/Tickets/tickets.tsx
@@ -9,9 +9,12 @@ const Tickets = (): JSX.Element => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const today = new Date();
 
-  const availableTickets: ITicket[] = tickets.filter(
-    (ticket: ITicket) => new Date(ticket.eventDate) > today
-  );
+  const availableTickets: ITicket[] = tickets.sort((a, b) => {
+    const aEnded = new Date(a.eventDate) < today;
+    const bEnded = new Date(b.eventDate) < today;
+    if (aEnded === bEnded) return 0;
+    return aEnded ? 1 : -1; 
+  });
 
   const nextTicket = (): void => {
     setCurrentIndex((prev) => (prev + 1) % availableTickets.length);
@@ -90,7 +93,11 @@ const Tickets = (): JSX.Element => {
                       </h3>
                       <p className="text-gray-500 mt-1">{ticket.description}</p>
                     </div>
-                    <div className="px-2 py-1 rounded-full text-sm font-medium text-gradient">
+                    <div
+                      className={`px-2 py-1 rounded-full text-sm font-medium ${
+                        isEnded ? 'bg-red-100 text-red-600' : 'text-gradient'
+                      }`}
+                    >
                       {isEnded ? 'Ended' : ticket.status}
                     </div>
                   </div>


### PR DESCRIPTION
Fixes #807 
This PR improves the Tickets section by keeping closed tickets visible instead of removing them entirely.
Tickets are now sorted so that upcoming/current tickets appear first and closed tickets appear at the bottom.
Closed tickets display a red “Ended” badge.
The “Get a Ticket” button is shown but disabled with the label “Event Ended.”
Closed tickets remain consistent in appearance with active tickets, ensuring a clean UI.
This provides a consistent carousel experience while clearly indicating which tickets are no longer available.

Before:
Closed tickets were completely hidden.
Inconsistent user experience.

After:
Closed tickets remain visible.
Red badge + disabled button show event is ended.

<img width="1920" height="962" alt="Screenshot (893)" src="https://github.com/user-attachments/assets/1c2bf041-54c6-47bc-9697-3050fdb7bb64" />
