### PR TITLE
fix(ui enhancement): remove Back-to-Top hover effect on small screens (#838)

### DIFF
--- a/components/Buttons/BackToTopButton.tsx
+++ b/components/Buttons/BackToTopButton.tsx
@@ -42,7 +42,7 @@ const BackToTopButton: React.FC = () => {
   return isVisible ? (
     <button
       onClick={scrollToTop}
-      className="back-to-top-button fixed bottom-8 right-8 w-12 h-12 rounded-full border-none font-semibold flex items-center justify-center cursor-pointer overflow-hidden z-50 outline-none transition-all duration-300 ease-in-out transform hover:scale-95 active:scale-90"
+      className="back-to-top-button fixed bottom-8 right-8 w-12 h-12 rounded-full border-none font-semibold flex items-center justify-center cursor-pointer overflow-hidden z-50 outline-none transition-all duration-300 ease-in-out transform active:scale-90 sm:hover:scale-95"
       aria-label="Back to top"
     >
       <Arrows

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -266,18 +266,20 @@ backdrop-filter: blur(10px); */
   box-shadow: 0px 0px 0px 4px rgba(180, 160, 255, 0.253);
 }
 
-.back-to-top-button:hover {
-  width: 140px;
-  border-radius: 50px;
-  background-color: rgb(181, 160, 255);
-}
+@media (min-width: 640px) {
+  .back-to-top-button:hover {
+    width: 140px;
+    border-radius: 50px;
+    background-color: rgb(181, 160, 255);
+  }
 
-.back-to-top-button:hover .back-to-top-icon {
-  transform: translateY(-200%);
-  opacity: 0;
-}
+  .back-to-top-button:hover .back-to-top-icon {
+    transform: translateY(-200%);
+    opacity: 0;
+  }
 
-.back-to-top-button:hover .back-to-top-text {
-  font-size: 13px;
-  opacity: 1;
+  .back-to-top-button:hover .back-to-top-text {
+    font-size: 13px;
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## **Description**

This pull request updates the Back-to-Top button behavior on small screens by removing the hover effect for mobile and touch devices.

### **What was changed**
- Removed global `hover:scale-95` transform from the Back-to-Top component.
- Added `sm:hover:scale-95` so hover effects apply only on screens ≥ 640px.
- Removed universal `.back-to-top-button:hover` styling from `globals.css`.
- Added hover styles back inside a responsive media query (`@media (min-width: 640px)`).
- Ensures hover interactions only activate on devices that support pointer hover.

https://github.com/user-attachments/assets/1ee8526b-a80a-4aee-8b94-62b421d2f076


---

## **Related issue(s)**
Fixes **#838**