### PR TITLE
fix: video container size on venue page

### DIFF
--- a/pages/venue/[id].tsx
+++ b/pages/venue/[id].tsx
@@ -164,20 +164,23 @@ function Venue({ city }: IVenue) {
       <div id="recordings" className="flex justify-center">
         {eventStatus === ConferenceStatus.ENDED ? (
           city.playlist && (
-            <div className=" pt-10 mb-24 mx-44 lg:mx-7 flex justify-center flex-col items-center w-[90%] h-[550px] sm:h-72">
+            <div className="pt-10 mb-24 container flex justify-center flex-col items-center">
               <h1 className="text-white font-bold text-5xl mb-10">
                 Recordings
               </h1>
-              <iframe
-                width="100%"
-                height="100%"
-                src={city.playlist}
-                title="YouTube video player"
-                frameBorder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                referrerPolicy="strict-origin-when-cross-origin"
-                allowFullScreen
-              ></iframe>
+              <div className="w-full max-w-4xl aspect-video">
+                <iframe
+                  width="100%"
+                  height="100%"
+                  src={city.playlist}
+                  title="YouTube video player"
+                  frameBorder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  referrerPolicy="strict-origin-when-cross-origin"
+                  allowFullScreen
+                  className="w-full h-full"
+                ></iframe>
+              </div>
             </div>
           )
         ) : (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- Fixed the video container size on venue pages to match YouTube video dimensions
- Replaced the wide container (90% width with large margins) with a responsive container using a 16:9 aspect ratio
- Ensures the recordings section displays videos at the correct size without extra spacing

**Related issue(s)**
Fixes #847 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

This is before the fix-
<img width="1394" height="430" alt="image" src="https://github.com/user-attachments/assets/0ae81139-6dcd-49a4-b96d-6826c0fd720f" />

This is after the fix-
<img width="1440" height="816" alt="Screenshot 2025-12-11 at 2 26 33 AM" src="https://github.com/user-attachments/assets/c779df2e-1046-45a7-ae40-2f09536ce424" />
