### PR TITLE
fix: make navbar transparent on load and blur after scroll/menu open

### DIFF
--- a/components/Navbar/navbar.tsx
+++ b/components/Navbar/navbar.tsx
@@ -15,6 +15,7 @@ function Navbar(): JSX.Element {
   const [show, setShow] = useState<string | null>(null);
   const [isSubMenuHovered, setIsSubMenuHovered] = useState<boolean>(false);
   const [focusedSubMenuItem, setFocusedSubMenuItem] = useState<number>(-1);
+  const [isScrolled, setIsScrolled] = useState<boolean>(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const svg = useRef<SVGSVGElement>(null);
   const subMenuRefs = useRef<(HTMLAnchorElement | null)[]>([]);
@@ -86,10 +87,24 @@ function Navbar(): JSX.Element {
     setFocusedSubMenuItem(-1);
   };
 
+  useEffect(() => {
+    const handleScroll = (): void => {
+      setIsScrolled(window.scrollY > 20);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const shouldBlur = isScrolled || drop;
+
   return (
     <div className="relative">
       <div
-        className={`container flex justify-center fixed items-center w-full backdrop-blur ${drop && 'bg-[#1B1130]/90'} top-0 z-[99] text-white`}
+        className={`container flex justify-center fixed items-center w-full top-0 z-[99] text-white transition-all duration-300 ${
+          shouldBlur ? 'backdrop-blur-md bg-[#1B1130]/80' : 'bg-transparent'
+        }`}
       >
         <div className="p-5 flex justify-between h-[75px] w-full items-center">
           <div


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Make the navbar transparent on initial load so the hero is fully visible.
- Add scroll detection to apply a blurred, semi-opaque navbar after scrolling >20px.
- Keep the blurred, semi-opaque navbar when the mobile menu is open.
- Smooth transitions for all navbar states across screen sizes.

https://drive.google.com/file/d/1COnxuNoFG2QFOWJS1qaOq8y_wBsC69pG/view?usp=sharing


**Related issue(s)**
Fixes #859 









<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->