### PR TITLE
fix(cfp): prevent stale form state in StepThree

### DIFF
--- a/components/Form/Cfp/stepThree.tsx
+++ b/components/Form/Cfp/stepThree.tsx
@@ -34,8 +34,8 @@ function StepThree({ setStep, setForm, data }: CfpStepProps): JSX.Element {
   const [value, setValue] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    setForm({ ...data, ...value });
-  }, [value]);
+    setForm((prevData) => ({ ...prevData, ...value }));
+  }, [value, setForm]);
 
   return (
     <form className="mt-3" onSubmit={(e) => setStep(e, 4)}>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## PR Title :  Fix stale form state update in CFP StepThree component

## Description:
* This PR fixes a potential stale state issue in the CFP multi-step form.
* The `StepThree` component was updating shared form state by spreading props inside a `useEffect`, which could overwrite newer updates from other steps. This PR updates the logic to use a functional state update, ensuring form data is always merged with the latest state.


## Solution:
* Updated `useEffect` in `StepThree` to use a functional `setForm` update
* Ensured form data from other steps is not unintentionally overwritten


## Impact:
* Prevents stale state bugs
* Improves reliability of CFP multi-step form
* No breaking changes

- Fixes #868 