### PR TITLE
fix: formatting in Popup component Missing spacing between "to" and "…

### DIFF
--- a/components/Popup/popup.tsx
+++ b/components/Popup/popup.tsx
@@ -108,7 +108,7 @@ function Popup() {
                     For the first time ever, we&apos;re bringing the AsyncAPI
                     community to
                     <br className="hidden sm:block" />
-                    DeveloperWeek USA in San Jose, CA
+                    {" "}DeveloperWeek USA in San Jose, CA
                   </Paragraph>
 
                   <Paragraph


### PR DESCRIPTION
## Bug Fix: Missing spacing between "to" and "DeveloperWeek"

### 📄 Description
There was no spacing between the words **"to"** and **"DeveloperWeek"** in the conference announcement text due to a line break (`<br />`) removing the implicit space in JSX.

### ✅ Fix
Added an explicit JSX space (`{" "}`) after the line break to ensure proper spacing in the rendered text.

### 🔍 Expected Behavior
A visible space appears between **"to"** and **"DeveloperWeek"** across all screen sizes.

### 🧪 How to Reproduce
1. Open the conference website
2. Navigate to the section mentioning DeveloperWeek
3. Observe the spacing between "to" and "DeveloperWeek"

### 🖥️ Environment
- **OS:** macOS  
- **Browser:** Arc  

### 📸 Screenshots
Before: ❌ No spacing  
<img width="1512" height="982" alt="528972180-0c22e6e9-c5c8-4f52-859c-e87f149378cf" src="https://github.com/user-attachments/assets/c75e49f1-7ec2-4325-99d8-1fde1f03d6d0" />

After: ✅ Proper spacing
<img width="1133" height="767" alt="Screenshot 2025-12-22 at 12 07 59 AM" src="https://github.com/user-attachments/assets/4a427248-1109-421e-8cc8-fbd139e5c5d0" />


### 🔗 Resolved Issues
- #885 

### 📘 Checklist
- [x] Read the Contributing Guidelines
- [x] Tested the fix locally
- [x] No breaking changes

