### PR TITLE
fix: resolve speaker card width inconsistency on smaller screens

### DIFF
--- a/components/Cards/SpeakerCard/SpeakerCard.tsx
+++ b/components/Cards/SpeakerCard/SpeakerCard.tsx
@@ -9,7 +9,7 @@ interface ISpeaker {
   className?: string;
 }
 
-function SpeakerCard({ name, title, image, location, className = '' }: ISpeaker): JSX.Element {
+function SpeakerCard({ name, title, image, location, className }: ISpeaker): JSX.Element {
   function getName(names: string[]) {
     return `${names[0]} ${names[1]}`;
   }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

-   Fixed inconsistent speaker card widths on smaller screens by replacing `w-fit` with `w-full` in `SpeakerCard.tsx`
- `w-fit` was causing each card to size itself based on its content, resulting in unequal card widths
- `w-full` ensures all cards take the full width of their grid cell consistently


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #954