### PR TITLE
feat: add animated transition between venue list and details view in VenueSelector

### DIFF
--- a/app/meetups/components/VenueSelector.tsx
+++ b/app/meetups/components/VenueSelector.tsx
@@ -43,10 +43,11 @@ function VenueSelector({
           </Paragraph>
         </motion.div>
 
-        <AnimatePresence>
+        <AnimatePresence mode="wait">
           {!selectedVenue && (
             <motion.div
-              className="mt-20"
+              key="venue-list"
+              className="mt-20 min-h-[220px]"
               variants={containerVariants}
               initial="hidden"
               animate="visible"
@@ -68,43 +69,50 @@ function VenueSelector({
               </div>
             </motion.div>
           )}
-        </AnimatePresence>
 
-        {selectedVenue && (
-          <div className="mt-20 text-left sm:mt-12">
-            <Button
-              type="button"
-              className="mb-10 flex items-center sm:mb-6"
-              onClick={() => onVenueSelect(null)}
-              outline
-              icon={<Arrow className="w-4 rotate-180" />}
-              iconPosition="left"
+          {selectedVenue && (
+            <motion.div
+              key="venue-details"
+              className="mt-20 text-left sm:mt-12 min-h-[220px]"
+              variants={containerVariants}
+              initial="hidden"
+              animate="visible"
+              exit="hidden"
             >
-              <div className="ml-2 text-white text-md">
-                {selectedVenue.country}
-              </div>
-            </Button>
+              <Button
+                type="button"
+                className="mb-10 flex items-center sm:mb-6"
+                onClick={() => onVenueSelect(null)}
+                outline
+                icon={<Arrow className="w-4 rotate-180" />}
+                iconPosition="left"
+              >
+                <div className="ml-2 text-white text-md">
+                  {selectedVenue.country}
+                </div>
+              </Button>
 
-            {selectedVenue.cities.length > 0 ? (
-              <div className="grid grid-cols-3 gap-4 lg:grid-cols-2 sm:grid-cols-1">
-                {selectedVenue.cities.map((city) => (
-                  <Button
-                    type="button"
-                    outline
-                    key={city.name}
-                    className="text-white border border-white/20 px-6 py-3 rounded-full text-center"
-                  >
-                    {city.name}
-                  </Button>
-                ))}
-              </div>
-            ) : (
-              <Paragraph className="text-gray-300 text-center">
-                No meetups in this country yet. Stay tuned!
-              </Paragraph>
-            )}
-          </div>
-        )}
+              {selectedVenue.cities.length > 0 ? (
+                <div className="grid grid-cols-3 gap-4 lg:grid-cols-2 sm:grid-cols-1">
+                  {selectedVenue.cities.map((city) => (
+                    <Button
+                      type="button"
+                      outline
+                      key={city.name}
+                      className="text-white border border-white/20 px-6 py-3 rounded-full text-center"
+                    >
+                      {city.name}
+                    </Button>
+                  ))}
+                </div>
+              ) : (
+                <Paragraph className="text-gray-300 text-center">
+                  No meetups in this country yet. Stay tuned!
+                </Paragraph>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
         <motion.div variants={itemVariants}>
           <Paragraph className="mt-10" typeStyle="body-md">
             Please be sure to read and understand our Terms & Conditions for{' '}


### PR DESCRIPTION
**Description**

* Fixed an issue in `VenueSelector.tsx` where toggling a meetup country caused a jarring layout shift.
* The root cause was that the entering element (`venue-details`) was placed outside the `<AnimatePresence>` block, which caused it to render simultaneously with the exiting element (`venue-list`). Additionally, height differences between the country list and empty state views caused the content below it to jump.
* Restructured the component by wrapping both conditionally rendered views inside a single `<AnimatePresence mode="wait">`.
* Added a `min-h-[220px]` class to the animated containers to reserve stable layout space, preventing the content below from shifting when navigating between the list and empty states.

**Testing**

### Before Fix

As shown below, clicking a country causes a visible layout shift because both views are mounted simultaneously and the container height collapses during the transition.

<video src="https://github.com/user-attachments/assets/d704ec33-46a1-4022-b7a3-4467d33837fc" controls autoplay muted loop></video>

### After Fix

With `mode="wait"` and a stable `min-h-[220px]`, the transition handles entering and exiting components smoothly without disrupting the surrounding layout.

<video src="https://github.com/user-attachments/assets/815c2176-9670-41d6-8504-d72d13145cdc" controls autoplay muted loop></video>

**Related issue(s)**

Fixes #1031
