### PR TITLE
fix: align navbar width and pin footer to viewport bottom

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -15,9 +15,9 @@ export default function ClientLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div>
+    <div className="flex min-h-screen flex-col">
       <Navbar />
-      {children}
+      <main className="flex-1">{children}</main>
       <Footer />
       <BackToTopButton />
     </div>

--- a/components/Navbar/navbar.tsx
+++ b/components/Navbar/navbar.tsx
@@ -94,7 +94,7 @@ function Navbar(): JSX.Element {
       <div
         className={`flex justify-center fixed items-center w-full backdrop-blur ${drop && 'bg-[#1B1130]/90'} top-0 z-[99] text-white`}
       >
-        <div className="p-5 flex justify-between h-[75px] w-full items-center">
+        <div className="container flex justify-between h-[75px] items-center">
           <div
             className="flex items-center sm:justify-between sm:w-full z-[99]"
             data-test="nav-Home"


### PR DESCRIPTION
## What changed

Addresses the layout part of #1029: the navbar now uses the same \container\ width as the rest of the page, and the footer stays pinned to the bottom of the viewport on short pages via a \min-h-screen\ flex layout.

- Navbar: replaced the full-width \w-full\ inner wrapper with the shared \container\ class so nav content aligns with page content.
- Layout: \ClientLayout\ is now \lex min-h-screen flex-col\ with the page content in a \lex-1\ \main\, so the footer sits at the viewport bottom regardless of content height.

## Testing

Local build passes; existing cypress selectors (\
av-*\, \ooter\) are unchanged.

## Certification

- [x] I changed only layout files (components/Navbar/navbar.tsx, app/client-layout.tsx).
- [x] My commits include a Signed-off-by line.